### PR TITLE
Update link-example.cc

### DIFF
--- a/examples/link-example.cc
+++ b/examples/link-example.cc
@@ -168,7 +168,7 @@ main(int argc, char *argv[])
 
   NS_LOG_INFO("Create Applications.");
 
-  std::string protocols[users];
+  std::string *protocols = new std::string[users];
   std::stringstream ss(protocol);
   std::string proto;
   uint32_t protoNum = 0; // The number of protocols (algorithms)


### PR DESCRIPTION
Corrected the error in ns-3.26

"link-example.cc:171:24: error: variable length array of non-POD element type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >')
  std::string protocols[users];
"