### PR TITLE
Update dash-example.cc

### DIFF
--- a/examples/dash-example.cc
+++ b/examples/dash-example.cc
@@ -115,7 +115,7 @@ main(int argc, char *argv[])
 
   NS_LOG_INFO("Create Applications.");
 
-  std::string protocols[users];
+  std::string *protocols = new std::string[users];
   std::stringstream ss(protocol);
   std::string proto;
   uint32_t protoNum = 0; // The number of protocols (algorithms)


### PR DESCRIPTION
Corrected the error for ns-3.26 which was:

dash-example.cc:118:24: error: variable length array of non-POD element type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >')
  std::string protocols[users];